### PR TITLE
kevin's stuff

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import Footer from './Components/Footer/Footer';
 import Header from './Components/Navigation/Header';
 import Splash from './Components/Splash';
 import approvalIcon from './Assets/mobile_friendly_24px.png';
+import AdminView from './Components/AdminView';
 
 function App() {
   return (
@@ -26,6 +27,8 @@ function App() {
         <Route path="/dashboard/navigator" element={<NavigatorDashboard />} />
         <Route path="/reset" element={<Reset />} />
         <Route path="/profile" element={<Profile />} />
+        <Route path="/adminview" element={<AdminView />} />
+
         <Route
           path="/splash"
           element={(

--- a/src/Components/AdminView.css
+++ b/src/Components/AdminView.css
@@ -1,0 +1,11 @@
+.Card {
+    padding-left: 50px;
+    width: 180px;
+  }
+  
+  .Cards {
+    display: flex;
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+  

--- a/src/Components/AdminView.js
+++ b/src/Components/AdminView.js
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import {
+  collection, query, where, getDocs,
+} from 'firebase/firestore';
+import AvatarCard from './AvatarCard';
+import { db } from './firebase';
+import './AdminView.css';
+
+export default function AdminView() {
+  // query all seekers
+  const [archivedUsers, setArchivedUsers] = useState([]);
+
+  const getArchived = async () => {
+    const archived = [];
+    try {
+      const Ref = collection(db, 'jobseekers');
+      const q = query(Ref, where('archived', '==', true));
+      const querySnapshot = await getDocs(q);
+      querySnapshot.forEach((doc) => {
+        const data = doc.data();
+        const { id } = doc;
+        const js = {
+          data,
+          id,
+        };
+        archived.push(js);
+      });
+    } catch (error) {
+      console.log(error);
+    }
+    setArchivedUsers(archived);
+  };
+  useEffect(() => {
+    getArchived(setArchivedUsers);
+  }, []);
+  return (
+    <div className="Cards">
+      {archivedUsers.map((user) => (
+        <div className="Card">
+          <AvatarCard
+            user={user}
+            archivedUsers={archivedUsers}
+            setArchivedUsers={setArchivedUsers}
+          />
+
+        </div>
+      ))}
+    </div>
+
+  );
+}

--- a/src/Components/AvatarCard.css
+++ b/src/Components/AvatarCard.css
@@ -1,0 +1,33 @@
+.MuiPaper-root {
+    padding-bottom: 10px;
+}
+
+.Avatar {
+    display: inline-block;
+    height: 40px
+}
+
+.Menu {
+    display: inline-block;
+    height: 40px
+}
+
+.Info {
+    width: 100px;
+    height: 40px;
+    display: inline-block;
+    position: relative;
+    top: 10px;
+}
+
+.Name {
+    font-size: medium;
+    font-weight: 200;
+    margin: auto;
+}
+
+.Field {
+    font-size: small;
+    font-weight: 200;
+    margin: auto;
+}

--- a/src/Components/AvatarCard.js
+++ b/src/Components/AvatarCard.js
@@ -1,0 +1,105 @@
+import {
+  Paper, Avatar,
+} from '@mui/material';
+import React, { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {
+  doc, setDoc, deleteDoc,
+} from 'firebase/firestore';
+import { PropTypes } from 'prop-types';
+import { db } from './firebase';
+import './AvatarCard.css';
+
+const options = [
+  'Unarchive',
+  'Delete',
+];
+
+function AvatarCard({ user, archivedUsers, setArchivedUsers }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const updateArchived = async (id) => {
+    const Ref = doc(db, 'jobseekers', id);
+    setDoc(Ref, { archived: false }, { merge: true });
+  };
+
+  const deleteDocument = async (id) => {
+    await deleteDoc(doc(db, 'jobseekers', id));
+  };
+
+  const handleClose = async (index) => {
+    if (index === 0) {
+      await updateArchived(user.id);
+      const newUsers = archivedUsers.filter((seeker) => seeker.id !== user.id);
+      setArchivedUsers(newUsers);
+    }
+
+    if (index === 1) {
+      await deleteDocument(user.id);
+      const newUsers = archivedUsers.filter((seeker) => seeker.id !== user.id);
+      setArchivedUsers(newUsers);
+    }
+    setAnchorEl(null);
+  };
+
+  const { name } = user.data;
+  const field = user.data['field of work'];
+  return (
+    <Paper className="Contents" elevation={3} rounded>
+      <div className="Avatar">
+        <Avatar>{name.substring(0, 1).toUpperCase()}</Avatar>
+      </div>
+      <div className="Info">
+        <p className="Name">{name}</p>
+        <p className="Field">{field}</p>
+      </div>
+      <div className="Menu">
+        <IconButton
+          aria-label="more"
+          id="long-button"
+          aria-controls={open ? 'long-menu' : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-haspopup="true"
+          onClick={handleClick}
+        >
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          id="long-menu"
+          MenuListProps={{
+            'aria-labelledby': 'long-button',
+          }}
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          PaperProps={{
+            style: {
+              maxHeight: 20 * 4.5,
+              width: '20ch',
+            },
+          }}
+        >
+          {options.map((option, index) => (
+            <MenuItem key={option} onClick={() => { handleClose(index); }}>
+              {option}
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    </Paper>
+
+  );
+}
+AvatarCard.propTypes = {
+  user: PropTypes.shape.isRequired,
+  setArchivedUsers: PropTypes.func.isRequired,
+  archivedUsers: PropTypes.arrayOf(PropTypes.shape).isRequired,
+};
+export default AvatarCard;

--- a/src/Components/Dropdown.js
+++ b/src/Components/Dropdown.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+
+const options = [
+  'Unarchive',
+  'Delete',
+];
+
+const ITEM_HEIGHT = 48;
+
+function Dropdown() {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <IconButton
+        aria-label="more"
+        id="long-button"
+        aria-controls={open ? 'long-menu' : undefined}
+        aria-expanded={open ? 'true' : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        id="long-menu"
+        MenuListProps={{
+          'aria-labelledby': 'long-button',
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          style: {
+            maxHeight: ITEM_HEIGHT * 4.5,
+            width: '20ch',
+          },
+        }}
+      >
+        {options.map((option) => (
+          <MenuItem key={option} onClick={handleClose}>
+            {option}
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+}
+export default Dropdown;

--- a/src/Pages/Checkboxes.css
+++ b/src/Pages/Checkboxes.css
@@ -2,4 +2,5 @@
 
 .label {
     margin-left: 50;
+    padding-left: 10px;
 }


### PR DESCRIPTION
Added a way for all archived users to be displayed during the admin view. Clicking the button opens the menu that allows to either delete or unarchive a user.

TODO:
As far as adding functionality for making the data downloadable if we want it in a spreadsheet the best bet is still the google sheets api. Their api can add 1 page at a time at most so it seems that you'll have to add each sheet at a time. It also seems like to use a Google api you're going to need to setup a google cloud project the link to a quickstart for that is here: https://developers.google.com/sheets/api/quickstart/js

Now whenever an admin attempts to download a users data to a spreadsheet you would create a spreadsheet: https://developers.google.com/sheets/api/guides/create

Then to add an individual page you would use the spreadsheets.batchUpdate method (documentation here: https://developers.google.com/sheets/api/guides/batchupdate#javascript). The requests will contain an AddSheetRequest (I think) (https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request#AddSheetRequest). An example in python can be found here: https://stackoverflow.com/questions/41445723/how-can-i-add-a-new-tab-to-an-existing-sheet-via-the-google-sheets-api

From there you would have to update the sheet which I believe can be done using spreadsheets.values.batchUpdate method (documentation here: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchUpdate).

You would then repeat the process adding as many sheets to the spreadsheet as you need to.

Side Note:
I think this is right way to do it but I couldn't find an example so it may be flawed.